### PR TITLE
docs: add Traditional Chinese README and improve formatting consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 # Maturity Models
 
+[繁體中文版](README.zh_TW.md)
+
 <img src="README.png" alt="Maturity Models" style="width: 100%;"/>
 
 A maturity model is a business tool used to assess people/culture, processes/structures, and objects/technology.
@@ -16,43 +18,44 @@ A maturity model is a business tool used to assess people/culture, processes/str
 See https://en.wikipedia.org/wiki/Maturity_model
 
 Contents:
-- [Maturity model levels](#maturity-model-levels)
-- [Maturity model examples](#maturity-model-examples)
-- [Maturity model process perspectives](#maturity-model-process-perspectives)
-- [Top-down vs. bottom-up](#top-down-vs-bottom-up)
-- [Modeling Maturing Levels](#modeling-maturing-levels)
-- [Rebuttals to maturity models](#rebuttals-to-maturity-models)
-- [Related assessment metrics](#related-assessment-metrics)
-- [FAQ](#faq)
-  - [Can I create a maturity model?](#can-i-create-a-maturity-model)
-  - [Who decides what goes into a maturity model?](#who-decides-what-goes-into-a-maturity-model)
-  - [Is a maturity model a snapshot in time or a future plan?](#is-a-maturity-model-a-snapshot-in-time-or-a-future-plan)
-  - [Is a maturity model descriptive or prescriptive?](#is-a-maturity-model-descriptive-or-prescriptive)
-  - [Can a maturity model evolve over time?](#can-a-maturity-model-evolve-over-time)
-  - [Does a maturity model have an end state?](#does-a-maturity-model-have-an-end-state)
-  - [Is a maturity model different than a scientific model?](#is-a-maturity-model-different-than-a-scientific-model)
-  - [Is a maturity models verifiable?](#is-a-maturity-models-verifiable)
+
+- [Maturity Models](#maturity-models)
+  - [Maturity model levels](#maturity-model-levels)
+  - [Maturity model examples](#maturity-model-examples)
+  - [Maturity model process perspectives](#maturity-model-process-perspectives)
+  - [Top-down vs. bottom-up](#top-down-vs-bottom-up)
+  - [Modeling Maturing Levels](#modeling-maturing-levels)
+  - [Rebuttals to maturity models](#rebuttals-to-maturity-models)
+  - [Related assessment metrics](#related-assessment-metrics)
+  - [FAQ](#faq)
+    - [Can I create a maturity model?](#can-i-create-a-maturity-model)
+    - [Who decides what goes into a maturity model?](#who-decides-what-goes-into-a-maturity-model)
+    - [Is a maturity model a snapshot in time or a future plan?](#is-a-maturity-model-a-snapshot-in-time-or-a-future-plan)
+    - [Is a maturity model descriptive or prescriptive?](#is-a-maturity-model-descriptive-or-prescriptive)
+    - [Can a maturity model evolve over time?](#can-a-maturity-model-evolve-over-time)
+    - [Does a maturity model have an end state?](#does-a-maturity-model-have-an-end-state)
+    - [Is a maturity model different than a scientific model?](#is-a-maturity-model-different-than-a-scientific-model)
+    - [Is a maturity models verifiable?](#is-a-maturity-models-verifiable)
 
 ## Maturity model levels
 
 Maturity model levels are typically a series of steps of sophistication such as:
 
-* Level 0: Not Applicable
-* Level 1: Initiate
-* Level 2: Develop
-* Level 3: Standardize
-* Level 4: Manage
-* Level 5: Orchestrate
+- Level 0: Not Applicable
+- Level 1: Initiate
+- Level 2: Develop
+- Level 3: Standardize
+- Level 4: Manage
+- Level 5: Orchestrate
 
 Maturity model levels have a range of terminology in various industries such as:
 
-* Level 0: None, Never, Negligible, Not Applicable.
-* Level 1: Initiate, Investigate, Implicit, Individual-oriented, Informal-usage.
-* Level 2: Develop, Describe, Duplicate, Direct-oriented, Department-usage.
-* Level 3: Standardize, Specify, Scale, Service-oriented, Segment-usage
-* Level 4: Manage, Measure, Mainstream, Mission-oriented, Mass-usage.
-* Level 5: Orchestrate, Originate, Ongoing, Opportunity-oriented, Outsize-usage
-
+- Level 0: None, Never, Negligible, Not Applicable.
+- Level 1: Initiate, Investigate, Implicit, Individual-oriented, Informal-usage.
+- Level 2: Develop, Describe, Duplicate, Direct-oriented, Department-usage.
+- Level 3: Standardize, Specify, Scale, Service-oriented, Segment-usage
+- Level 4: Manage, Measure, Mainstream, Mission-oriented, Mass-usage.
+- Level 5: Orchestrate, Originate, Ongoing, Opportunity-oriented, Outsize-usage
 
 ## Maturity model examples
 
@@ -60,165 +63,152 @@ We welcome examples of maturity models. If you know of a maturity model, please 
 
 General maturity models:
 
-  * [U.S. N.I.H. Proficiency Scale](examples/skill/us-nih-proficiency-scale/index.md)
-  * [Dreyfus model of skill acquisition](examples/skill/dreyfus-model-of-skill-acquisition/index.md)
-  
+- [U.S. N.I.H. Proficiency Scale](examples/skill/us-nih-proficiency-scale/index.md)
+- [Dreyfus model of skill acquisition](examples/skill/dreyfus-model-of-skill-acquisition/index.md)
+
 Topic maturity models:
 
-* Agile
-  * [Agile Compass for maturity in agile teams](examples/agile/agile-compass-for-maturity-in-agile-teams/index.md)
-  * [Agile Fluency](examples/agile/agile-fluency/index.md)
-  * [Agile DevOps Maturity Model by Hewlett Packard Enterprise (HPE)](examples/agile/agile-devops-maturity-model-by-hewlett-packard-enterprise-hpe/index.md)
-  * [Agile Maturity Model (AMM) by ThoughtWorks (TW)](examples/agile/agile-maturity-model-by-thoughtworks/index.md)
-  * [Agile Team Maturity Model by Prowareness](examples/agile/agile-team-maturity-model-by-prowareness/index.md)
-* Capability
-  * [Capability Maturity Model Integration (CMMI) for Development by Carnegie Mellon Software Engineering Institute (SEI)](http://resources.sei.cmu.edu/asset-files/TechnicalReport/2006-005-001-14771.pdf)
-  * [Capability Maturity Model Integration (CMMI) for Acquisition by Carnegie Mellon Software Engineering Institute (SEI)](http://resources.sei.cmu.edu/asset-files/TechnicalReport/2007-005-001-14897.pdf)
-* Continous Improvement
-  * [Continuous Improvement Meetings Maturity Model](continuous-improvement-meetings-maturity-model/index.md)
-* Continuous Delivery
-  * [Continuous Delivery Maturity Model by Xebia](examples/continuous-delivery/continuous-delivery-maturity-model-by-xebia/index.md)
-* Data Center
-  * [Data Center Automation Maturity Model by Xebia](examples/data-center/data-center-automation-maturity-model-by-xebia/index.md)
-* Enterprise Architecture
-  * [Enterprise Architecture: TOGAF Maturity Model](examples/software/enterprise-architecture/togaf-maturity-model/index.md)
-  * [Enterprise Architecture Maturity Model based on CMMI CM SEI](examples/software/enterprise-architecture/enterprise-architecture-maturity-model-based-on-cmmi-cm-sei/index.md)
-* EIM : Enterprise Information Management
-  * [EIM Maturity Model by Gartner](examples/eim/gartner-eim-maturity-model/index.md)
-* Green Software
-  * [Green Software Maturity Matrix](https://maturity-matrix.greensoftware.foundation/) 
-* IAM: Identity and Access Management
-  * [IAM Program Maturity Model by Gartner](examples/iam/iam-program-maturity-model-by-gartner/index.md)
-* Infrastructure as Code (IaC)
-  * [Infrastructure as Code maturity model by Joel Parker Henderson](examples/infrastructure-as-code/infrastructure-as-code-maturity-model-by-joel-parker-henderson/index.md)
-  * [Infrastructure as Code maturity model by Stafford](examples/infrastructure-as-code/infrastructure-as-code-maturity-model-by-stafford/index.md)
-* IT: Information Technology
-  * [IT Capability Maturity Framework by the Innovation Value Institute (IVI)](examples/it/it-capability-maturity-framework-by-innovation-value-institute/index.md)
-  * [Technical Leadership Career Ladder by Poss](examples/it/technical-leadership-career-ladder-by-poss/)
-* Management
-  * [Program and Portfolio Management Maturity Model by Gartner](examples/management/program-and-portfolio-management-maturity-model-by-gartner/index.md)
-  * [Project Portfolio Management Maturity Levels by Priority Systems](examples/management/project-portfolio-management-maturity-levels-by-priority-systems/index.md)
-  * [Portfolio, Programme & Project Management Maturity Model (P3M3) by OGC](examples/management/porfolio-programme-project-management-maturity-model-p3m3-by-ogc/index.md)
-* Open Source
-  * [OpenSource Maturity Model](examples/software/open-source/opensource-maturity-model/index.md)
-* Product
-  * [Kwan’s Hierarchy of Product Needs](examples/product/kwans-hierarchy-of-product-needs/index.md)
-* PS: Professional Services
-  * [PS maturity scorecard by SPI Research](examples/ps/ps-maturity-scorecard-by-spi-research/index.md)
-* Skills
-  * [Programmer competency matrix](examples/programming/programmer-competentcy-matrix/index.md)
-  * [Skills maturity model by Prowareness](examples/skill/skills-maturity-model-by-prowareness/index.md)
-* Six Sigma
-  * [Lean Six Sigma Maturity Model](examples/six-sigma/lean-six-sigma-maturity-model/index.md)
-  * [The Six Sigma Maturity Model™](examples/six-sigma/six-sigma-maturity-model/index.md)
-* Social Media
-  * [Social Media Maturity Model](examples/social-media/social-media-maturity-model/index.md)
-* Software Documenation
-  * [README Maturity Model](examples/software-documentation/readme-maturity-model/index.md)
-* Team
-  * [Team Capability Maturity Model by novumAVI](examples/team/team-capability-maturity-model-by-novumavi/index.md)
-  * [Team Performance Maturity Model](examples/team/team-performance-maturity-model/index.md)
-* Vendors
-  * [Apache Project Maturity Model](https://community.apache.org/apache-way/apache-project-maturity-model.html)
-  
-  
+- Agile
+  - [Agile Compass for maturity in agile teams](examples/agile/agile-compass-for-maturity-in-agile-teams/index.md)
+  - [Agile Fluency](examples/agile/agile-fluency/index.md)
+  - [Agile DevOps Maturity Model by Hewlett Packard Enterprise (HPE)](examples/agile/agile-devops-maturity-model-by-hewlett-packard-enterprise-hpe/index.md)
+  - [Agile Maturity Model (AMM) by ThoughtWorks (TW)](examples/agile/agile-maturity-model-by-thoughtworks/index.md)
+  - [Agile Team Maturity Model by Prowareness](examples/agile/agile-team-maturity-model-by-prowareness/index.md)
+- Capability
+  - [Capability Maturity Model Integration (CMMI) for Development by Carnegie Mellon Software Engineering Institute (SEI)](http://resources.sei.cmu.edu/asset-files/TechnicalReport/2006-005-001-14771.pdf)
+  - [Capability Maturity Model Integration (CMMI) for Acquisition by Carnegie Mellon Software Engineering Institute (SEI)](http://resources.sei.cmu.edu/asset-files/TechnicalReport/2007-005-001-14897.pdf)
+- Continous Improvement
+  - [Continuous Improvement Meetings Maturity Model](continuous-improvement-meetings-maturity-model/index.md)
+- Continuous Delivery
+  - [Continuous Delivery Maturity Model by Xebia](examples/continuous-delivery/continuous-delivery-maturity-model-by-xebia/index.md)
+- Data Center
+  - [Data Center Automation Maturity Model by Xebia](examples/data-center/data-center-automation-maturity-model-by-xebia/index.md)
+- Enterprise Architecture
+  - [Enterprise Architecture: TOGAF Maturity Model](examples/software/enterprise-architecture/togaf-maturity-model/index.md)
+  - [Enterprise Architecture Maturity Model based on CMMI CM SEI](examples/software/enterprise-architecture/enterprise-architecture-maturity-model-based-on-cmmi-cm-sei/index.md)
+- EIM : Enterprise Information Management
+  - [EIM Maturity Model by Gartner](examples/eim/gartner-eim-maturity-model/index.md)
+- Green Software
+  - [Green Software Maturity Matrix](https://maturity-matrix.greensoftware.foundation/)
+- IAM: Identity and Access Management
+  - [IAM Program Maturity Model by Gartner](examples/iam/iam-program-maturity-model-by-gartner/index.md)
+- Infrastructure as Code (IaC)
+  - [Infrastructure as Code maturity model by Joel Parker Henderson](examples/infrastructure-as-code/infrastructure-as-code-maturity-model-by-joel-parker-henderson/index.md)
+  - [Infrastructure as Code maturity model by Stafford](examples/infrastructure-as-code/infrastructure-as-code-maturity-model-by-stafford/index.md)
+- IT: Information Technology
+  - [IT Capability Maturity Framework by the Innovation Value Institute (IVI)](examples/it/it-capability-maturity-framework-by-innovation-value-institute/index.md)
+  - [Technical Leadership Career Ladder by Poss](examples/it/technical-leadership-career-ladder-by-poss/)
+- Management
+  - [Program and Portfolio Management Maturity Model by Gartner](examples/management/program-and-portfolio-management-maturity-model-by-gartner/index.md)
+  - [Project Portfolio Management Maturity Levels by Priority Systems](examples/management/project-portfolio-management-maturity-levels-by-priority-systems/index.md)
+  - [Portfolio, Programme & Project Management Maturity Model (P3M3) by OGC](examples/management/porfolio-programme-project-management-maturity-model-p3m3-by-ogc/index.md)
+- Open Source
+  - [OpenSource Maturity Model](examples/software/open-source/opensource-maturity-model/index.md)
+- Product
+  - [Kwan’s Hierarchy of Product Needs](examples/product/kwans-hierarchy-of-product-needs/index.md)
+- PS: Professional Services
+  - [PS maturity scorecard by SPI Research](examples/ps/ps-maturity-scorecard-by-spi-research/index.md)
+- Skills
+  - [Programmer competency matrix](examples/programming/programmer-competentcy-matrix/index.md)
+  - [Skills maturity model by Prowareness](examples/skill/skills-maturity-model-by-prowareness/index.md)
+- Six Sigma
+  - [Lean Six Sigma Maturity Model](examples/six-sigma/lean-six-sigma-maturity-model/index.md)
+  - [The Six Sigma Maturity Model™](examples/six-sigma/six-sigma-maturity-model/index.md)
+- Social Media
+  - [Social Media Maturity Model](examples/social-media/social-media-maturity-model/index.md)
+- Software Documenation
+  - [README Maturity Model](examples/software-documentation/readme-maturity-model/index.md)
+- Team
+  - [Team Capability Maturity Model by novumAVI](examples/team/team-capability-maturity-model-by-novumavi/index.md)
+  - [Team Performance Maturity Model](examples/team/team-performance-maturity-model/index.md)
+- Vendors
+  - [Apache Project Maturity Model](https://community.apache.org/apache-way/apache-project-maturity-model.html)
+
 ## Maturity model process perspectives
 
 P3M3® describes process perspectives. These can be assessed at all maturity model levels.
 
-* Control Management: how well the organization maintains control of the initiatives currently ‘in flight’.
-* Benefits Management: how well the organization defines, tracks and ensures achievement of performance improvement from the investment.
-* Financial Management: how well the organization manages and controls the investment through business cases and budgetary control.
-* Stakeholder Management: how well the initiatives engage with and communicate with the external environment to minimize the negative implications engagement can achieve.
-* Organizational Governance: how well the organization controls the initiation and alignment of its investments with the corporate strategy.
-* Risk Management: how well the organization focuses on and mitigates the impact of threats and the leveraging of opportunities.
-* Resource Management: how well the organization develops its own talent and utilizes the opportunities from the supply chain to overcome peaks and troughs.
-
+- Control Management: how well the organization maintains control of the initiatives currently ‘in flight’.
+- Benefits Management: how well the organization defines, tracks and ensures achievement of performance improvement from the investment.
+- Financial Management: how well the organization manages and controls the investment through business cases and budgetary control.
+- Stakeholder Management: how well the initiatives engage with and communicate with the external environment to minimize the negative implications engagement can achieve.
+- Organizational Governance: how well the organization controls the initiation and alignment of its investments with the corporate strategy.
+- Risk Management: how well the organization focuses on and mitigates the impact of threats and the leveraging of opportunities.
+- Resource Management: how well the organization develops its own talent and utilizes the opportunities from the supply chain to overcome peaks and troughs.
 
 ## Top-down vs. bottom-up
 
 Two approaches for designing maturity models exist:
 
-* Top-down approach: a fixed number of maturity stages or levels is specified first, then corroborated with characteristics (typically in form of specific assessment items) that support the initial assumptions about how maturity evolves.
+- Top-down approach: a fixed number of maturity stages or levels is specified first, then corroborated with characteristics (typically in form of specific assessment items) that support the initial assumptions about how maturity evolves.
 
-* Bottom-up approach: distinct characteristics or assessment items are determined first, then clustered in a second step into maturity levels to induce a more general view of the different steps of maturity evolution.
-
+- Bottom-up approach: distinct characteristics or assessment items are determined first, then clustered in a second step into maturity levels to induce a more general view of the different steps of maturity evolution.
 
 ## Modeling Maturing Levels
 
 Modeling Maturity Levels is a classification system defined by Anneke Kleppe and Jos Warmer in their book MDA Explained Addison-Wesley. The levels characterize the role of modeling in a software project. The concept shows resemblance to the way software processes are rated with the Capability Maturity Model.
 
 See:
-* https://en.wikipedia.org/wiki/Modeling-Maturity-Levels
-* http://www.devx.com/enterprise/Article/26664
+
+- https://en.wikipedia.org/wiki/Modeling-Maturity-Levels
+- http://www.devx.com/enterprise/Article/26664
 
 There are 6 levels:
 
-* <b>Level 0: No Specification</b>: the specification of software is not written down. It is kept in the minds of the developers
- 
-* <b>Level 1: Textual Specification</b>: the software is specified by a natural language text (be it English or Chinese or something else), written down in one or more documents
+- <b>Level 0: No Specification</b>: the specification of software is not written down. It is kept in the minds of the developers
 
-* <b>Level 2: Text with Models</b>: a textual specification is enhanced with several models to show some of the main structures of the system
+- <b>Level 1: Textual Specification</b>: the software is specified by a natural language text (be it English or Chinese or something else), written down in one or more documents
 
-* <b>Level 3: Models with Text</b>: the specification of software is written down in one or more models. In addition to these models, natural language text is used to explain details, the background, and the motivation of the models, but the core of the specifications lies in the models.
- 
-* <b>Level 4: Precise Models</b>: the specification of the software is written down in one or more models. Natural language can still be used to explain the background and motivation of the models, but it takes on the same role as comments in source code.
+- <b>Level 2: Text with Models</b>: a textual specification is enhanced with several models to show some of the main structures of the system
 
-* <b>Level 5: Models only</b>: the models are precise and detailed enough to allow complete code generation. The code generators at this level have become as trustworthy as compilers, therefore no developer needs to even look at the generated code.
+- <b>Level 3: Models with Text</b>: the specification of software is written down in one or more models. In addition to these models, natural language text is used to explain details, the background, and the motivation of the models, but the core of the specifications lies in the models.
 
+- <b>Level 4: Precise Models</b>: the specification of the software is written down in one or more models. Natural language can still be used to explain the background and motivation of the models, but it takes on the same role as comments in source code.
+
+- <b>Level 5: Models only</b>: the models are precise and detailed enough to allow complete code generation. The code generators at this level have become as trustworthy as compilers, therefore no developer needs to even look at the generated code.
 
 ## Rebuttals to maturity models
 
-* [Immaturity of Maturity Models by James Bach](http://www.satisfice.com/blog/archives/581)
-* [Maturity Models Have It Backwards by Michael Bolton](http://www.developsense.com/blog/2009/10/maturity-models-have-it-backwards/)
-* [No Best Practices by James Bach](http://www.satisfice.com/blog/archives/27)
-* [The Immaturity of CMM](http://www.satisfice.com/articles/cmm.shtml)
-* [Why Maturity Models Don’t Work by Barry O'Reilly](https://barryoreilly.com/explore/blog/why-maturity-models-dont-work/)
-
+- [Immaturity of Maturity Models by James Bach](http://www.satisfice.com/blog/archives/581)
+- [Maturity Models Have It Backwards by Michael Bolton](http://www.developsense.com/blog/2009/10/maturity-models-have-it-backwards/)
+- [No Best Practices by James Bach](http://www.satisfice.com/blog/archives/27)
+- [The Immaturity of CMM](http://www.satisfice.com/articles/cmm.shtml)
+- [Why Maturity Models Don’t Work by Barry O'Reilly](https://barryoreilly.com/explore/blog/why-maturity-models-dont-work/)
 
 ## Related assessment metrics
 
-* [The Excellence Audit Top 10 10 by Tom Peters](examples/the-excellence-audit-top-ten-by-tom-peters/index.md)
-* [Great Professional Service Firms - by Tom Peters](examples/great-professional-service-firms-by-tom-peters/index.md)
-
+- [The Excellence Audit Top 10 10 by Tom Peters](examples/the-excellence-audit-top-ten-by-tom-peters/index.md)
+- [Great Professional Service Firms - by Tom Peters](examples/great-professional-service-firms-by-tom-peters/index.md)
 
 ## FAQ
-
 
 ### Can I create a maturity model?
 
 Yes. Anyone can create a maturity model. For example, many organizations create their own maturity models, sometimes based on public maturity models, sometimes making use of internal confidential information, sometimes in consultation with experts and advisors. and so forth. This repository links to many maturity models that are created by many people and many organizations.
 
-
 ### Who decides what goes into a maturity model?
 
 The team that creates the maturity model decides what goes into it. For creating your own maturity models, we suggest using a "decision record" that can help your team research what you want to go in, and document your choices, in order to help other people understand and leverage your work.
-
 
 ### Is a maturity model a snapshot in time or a future plan?
 
 Snapshot. Good teams will leverage the snapshot in order to create future plans, such as plans to work toward a higher maturity model level.
 
-
 ### Is a maturity model descriptive or prescriptive?
 
-Descriptive. A maturity model describes the levels and their items, and does not prescribe how a team moves from one level to the next, or acquires items. In rare cases, a specific maturity model may provide adjuct advice, yet this is inherent to the maturity model. 
-
+Descriptive. A maturity model describes the levels and their items, and does not prescribe how a team moves from one level to the next, or acquires items. In rare cases, a specific maturity model may provide adjuct advice, yet this is inherent to the maturity model.
 
 ### Can a maturity model evolve over time?
 
-Yes. As an organization evolves, each of its maturity models can evolve. For example, some organizations like to look ove each of their maturity models, each year, to ensure that each maturity model is still useful, and also to update each model as desired, based n the organization's goals and capabilities. 
-
+Yes. As an organization evolves, each of its maturity models can evolve. For example, some organizations like to look ove each of their maturity models, each year, to ensure that each maturity model is still useful, and also to update each model as desired, based n the organization's goals and capabilities.
 
 ### Does a maturity model have an end state?
 
 Yes. Then end state of a maturity model is when it is no longer useful to a team. For example, this can happen when a team decides that its current capabilties are fine as is, or when a team outgrows a maturity model by acheiving its highest level then wanting to improve even more.
 
-
 ### Is a maturity model different than a scientific model?
 
 Yes. A maturity model is intended to be a quick easy summary in order to help a team communicate about its current capabilties, and plan for future capabilties. The word "model" has the meaning "a small thing that represents another thing, that is often larger, or more complex, or more abstract." For comparison a "scientific model" is intended to explain and predict the behaviour of a real object or system, such as a visualization model that can contextualize a scientific object, or a predictive model that can foreccast a scientific system.
-
 
 ### Is a maturity models verifiable?
 

--- a/README.zh_TW.md
+++ b/README.zh_TW.md
@@ -1,0 +1,210 @@
+<!--
+  * browser: maturity-models
+  * tracker: f44c30d1b876f8987cf78c727e573542
+  * version: 7.1.0
+  * updated: 2021-12-14T03:24:14Z
+  * contact: Joel Parker Henderson (http://joelparkerhenderson.com)
+  * options: commentable
+-->
+
+# 成熟度模型（Maturity Models）
+
+[English README](README.md)
+
+<img src="README.png" alt="成熟度模型" style="width: 100%;"/>
+
+成熟度模型是一種商業工具，用於評估人員／文化、流程／結構，以及物件／技術。
+
+參見：https://zh.wikipedia.org/wiki/成熟度模型
+
+## 目錄
+
+- [成熟度模型（Maturity Models）](#成熟度模型maturity-models)
+  - [目錄](#目錄)
+  - [成熟度模型等級](#成熟度模型等級)
+  - [成熟度模型範例](#成熟度模型範例)
+  - [成熟度模型流程觀點](#成熟度模型流程觀點)
+  - [自上而下 vs. 自下而上](#自上而下-vs-自下而上)
+  - [建模成熟度等級](#建模成熟度等級)
+  - [對成熟度模型的反駁](#對成熟度模型的反駁)
+  - [相關評估指標](#相關評估指標)
+  - [常見問題](#常見問題)
+    - [我可以創建成熟度模型嗎？](#我可以創建成熟度模型嗎)
+    - [誰決定成熟度模型的內容？](#誰決定成熟度模型的內容)
+    - [成熟度模型是時間快照還是未來規劃？](#成熟度模型是時間快照還是未來規劃)
+    - [成熟度模型是描述性還是規範性？](#成熟度模型是描述性還是規範性)
+    - [成熟度模型可以隨時間演進嗎？](#成熟度模型可以隨時間演進嗎)
+    - [成熟度模型有終點嗎？](#成熟度模型有終點嗎)
+    - [成熟度模型與科學模型有何不同？](#成熟度模型與科學模型有何不同)
+    - [成熟度模型可驗證嗎？](#成熟度模型可驗證嗎)
+
+## 成熟度模型等級
+
+成熟度模型等級通常是一系列的成熟步驟，例如：
+
+- 等級 0：不適用
+- 等級 1：啟動
+- 等級 2：發展
+- 等級 3：標準化
+- 等級 4：管理
+- 等級 5：協同
+
+各行業對成熟度模型等級的術語有所不同，例如：
+
+- 等級 0：無、從未、可忽略、不適用
+- 等級 1：啟動、調查、隱含、個人導向、非正式使用
+- 等級 2：發展、描述、複製、直接導向、部門使用
+- 等級 3：標準化、規範、擴展、服務導向、區段使用
+- 等級 4：管理、衡量、主流、任務導向、大規模使用
+- 等級 5：協同、創新、持續、機會導向、超大規模使用
+
+## 成熟度模型範例
+
+歡迎提供成熟度模型範例。如果您知道任何成熟度模型，請透過建立 GitHub issue 或 pull request 告知我們。
+
+一般成熟度模型：
+
+- [美國國家衛生研究院（NIH）能力等級量表](examples/skill/us-nih-proficiency-scale/index.md)
+- [Dreyfus 技能習得模型](examples/skill/dreyfus-model-of-skill-acquisition/index.md)
+
+主題成熟度模型：
+
+- 敏捷
+  - [敏捷團隊成熟度羅盤](examples/agile/agile-compass-for-maturity-in-agile-teams/index.md)
+  - [敏捷流暢度模型](examples/agile/agile-fluency/index.md)
+  - [HPE 敏捷 DevOps 成熟度模型](examples/agile/agile-devops-maturity-model-by-hewlett-packard-enterprise-hpe/index.md)
+  - [ThoughtWorks 敏捷成熟度模型（AMM）](examples/agile/agile-maturity-model-by-thoughtworks/index.md)
+  - [Prowareness 敏捷團隊成熟度模型](examples/agile/agile-team-maturity-model-by-prowareness/index.md)
+- 能力
+  - [卡內基美隆 SEI 能力成熟度模型整合（CMMI）- 開發](http://resources.sei.cmu.edu/asset-files/TechnicalReport/2006-005-001-14771.pdf)
+  - [卡內基美隆 SEI 能力成熟度模型整合（CMMI）- 採購](http://resources.sei.cmu.edu/asset-files/TechnicalReport/2007-005-001-14897.pdf)
+- 持續改進
+  - [持續改進會議成熟度模型](continuous-improvement-meetings-maturity-model/index.md)
+- 持續交付
+  - [Xebia 持續交付成熟度模型](examples/continuous-delivery/continuous-delivery-maturity-model-by-xebia/index.md)
+- 資料中心
+  - [Xebia 資料中心自動化成熟度模型](examples/data-center/data-center-automation-maturity-model-by-xebia/index.md)
+- 企業架構
+  - [TOGAF 企業架構成熟度模型](examples/software/enterprise-architecture/togaf-maturity-model/index.md)
+  - [基於 CMMI CM SEI 的企業架構成熟度模型](examples/software/enterprise-architecture/enterprise-architecture-maturity-model-based-on-cmmi-cm-sei/index.md)
+- 企業資訊管理（EIM）
+  - [Gartner EIM 成熟度模型](examples/eim/gartner-eim-maturity-model/index.md)
+- 綠色軟體
+  - [綠色軟體成熟度矩陣](https://maturity-matrix.greensoftware.foundation/)
+- 身分與存取管理（IAM）
+  - [Gartner IAM 計畫成熟度模型](examples/iam/iam-program-maturity-model-by-gartner/index.md)
+- 基礎設施即程式碼（IaC）
+  - [Joel Parker Henderson 基礎設施即程式碼成熟度模型](examples/infrastructure-as-code/infrastructure-as-code-maturity-model-by-joel-parker-henderson/index.md)
+  - [Stafford 基礎設施即程式碼成熟度模型](examples/infrastructure-as-code/infrastructure-as-code-maturity-model-by-stafford/index.md)
+- 資訊科技（IT）
+  - [IVI IT 能力成熟度框架](examples/it/it-capability-maturity-framework-by-innovation-value-institute/index.md)
+  - [Poss 技術領導職涯階梯](examples/it/technical-leadership-career-ladder-by-poss/)
+- 管理
+  - [Gartner 計畫與投資組合管理成熟度模型](examples/management/program-and-portfolio-management-maturity-model-by-gartner/index.md)
+  - [Priority Systems 專案投資組合管理成熟度等級](examples/management/project-portfolio-management-maturity-levels-by-priority-systems/index.md)
+  - [OGC P3M3 投資組合、計畫與專案管理成熟度模型](examples/management/porfolio-programme-project-management-maturity-model-p3m3-by-ogc/index.md)
+- 開源
+  - [開源成熟度模型](examples/software/open-source/opensource-maturity-model/index.md)
+- 產品
+  - [Kwan 產品需求層級](examples/product/kwans-hierarchy-of-product-needs/index.md)
+- 專業服務（PS）
+  - [SPI Research PS 成熟度評分卡](examples/ps/ps-maturity-scorecard-by-spi-research/index.md)
+- 技能
+  - [程式設計師能力矩陣](examples/programming/programmer-competentcy-matrix/index.md)
+  - [Prowareness 技能成熟度模型](examples/skill/skills-maturity-model-by-prowareness/index.md)
+- 六標準差
+  - [精實六標準差成熟度模型](examples/six-sigma/lean-six-sigma-maturity-model/index.md)
+  - [六標準差成熟度模型 ™](examples/six-sigma/six-sigma-maturity-model/index.md)
+- 社群媒體
+  - [社群媒體成熟度模型](examples/social-media/social-media-maturity-model/index.md)
+- 軟體文件
+  - [README 成熟度模型](examples/software-documentation/readme-maturity-model/index.md)
+- 團隊
+  - [novumAVI 團隊能力成熟度模型](examples/team/team-capability-maturity-model-by-novumavi/index.md)
+  - [團隊績效成熟度模型](examples/team/team-performance-maturity-model/index.md)
+- 供應商
+  - [Apache 專案成熟度模型](https://community.apache.org/apache-way/apache-project-maturity-model.html)
+
+## 成熟度模型流程觀點
+
+P3M3® 描述了流程觀點，可於所有成熟度模型等級進行評估。
+
+- 控制管理：組織對現行專案的控制能力
+- 效益管理：組織如何定義、追蹤並確保投資帶來的績效提升
+- 財務管理：組織如何透過商業案例與預算控制管理投資
+- 利害關係人管理：專案如何與外部環境互動，降低負面影響
+- 組織治理：組織如何將投資與企業策略對齊
+- 風險管理：組織如何聚焦並降低威脅、把握機會
+- 資源管理：組織如何培養人才並善用供應鏈資源
+
+## 自上而下 vs. 自下而上
+
+設計成熟度模型有兩種方法：
+
+- 自上而下：先定義成熟度階段，再以特徵（如評估項目）佐證階段假設
+- 自下而上：先定義特徵或評估項目，再歸納分群為成熟度階段
+
+## 建模成熟度等級
+
+建模成熟度等級（Modeling Maturity Levels）由 Anneke Kleppe 與 Jos Warmer 在其著作《MDA Explained》中提出。該等級描述建模在軟體專案中的角色，與能力成熟度模型（CMMI）有相似之處。
+
+參見：
+
+- https://en.wikipedia.org/wiki/Modeling-Maturity-Levels
+- http://www.devx.com/enterprise/Article/26664
+
+共分六級：
+
+- **等級 0：無規格**：軟體規格未書面化，僅存於開發者腦中
+- **等級 1：文字規格**：以自然語言（如中文、英文）撰寫於文件中
+- **等級 2：文字加模型**：以文字為主，輔以模型說明系統結構
+- **等級 3：模型加文字**：以模型為主，文字輔助說明細節、背景與動機
+- **等級 4：精確模型**：以模型完整描述，文字僅作註解
+- **等級 5：僅模型**：模型足以自動產生完整程式碼，開發者無需檢查產生碼
+
+## 對成熟度模型的反駁
+
+- [James Bach：成熟度模型的不成熟](http://www.satisfice.com/blog/archives/581)
+- [Michael Bolton：成熟度模型本末倒置](http://www.developsense.com/blog/2009/10/maturity-models-have-it-backwards/)
+- [James Bach：沒有最佳實踐](http://www.satisfice.com/blog/archives/27)
+- [CMM 的不成熟](http://www.satisfice.com/articles/cmm.shtml)
+- [Barry O'Reilly：為什麼成熟度模型行不通](https://barryoreilly.com/explore/blog/why-maturity-models-dont-work/)
+
+## 相關評估指標
+
+- [Tom Peters 卓越審核十大指標](examples/the-excellence-audit-top-ten-by-tom-peters/index.md)
+- [Tom Peters 優秀專業服務公司](examples/great-professional-service-firms-by-tom-peters/index.md)
+
+## 常見問題
+
+### 我可以創建成熟度模型嗎？
+
+可以。任何人都可以創建成熟度模型。許多組織會根據公開模型或內部資訊自行設計，或諮詢專家顧問。本專案收錄了來自不同組織與個人的多種成熟度模型。
+
+### 誰決定成熟度模型的內容？
+
+創建團隊自行決定內容。建議使用「決策記錄」來協助團隊研究、記錄選擇，方便他人理解與應用。
+
+### 成熟度模型是時間快照還是未來規劃？
+
+是時間快照。優秀團隊會以快照為基礎，規劃未來提升成熟度的路徑。
+
+### 成熟度模型是描述性還是規範性？
+
+描述性。成熟度模型描述等級與項目，不規範如何晉級。少數模型會附加建議，但這屬於模型本身特性。
+
+### 成熟度模型可以隨時間演進嗎？
+
+可以。組織成長時，成熟度模型也可調整。例如每年檢視模型，確保其持續有用並依目標更新。
+
+### 成熟度模型有終點嗎？
+
+有。當模型對團隊不再有用時即為終點。例如團隊已達最高等級或能力，或決定現狀已足夠。
+
+### 成熟度模型與科學模型有何不同？
+
+不同。成熟度模型是協助團隊溝通現況與規劃未來的簡明工具。「模型」意指代表更大、更複雜或抽象事物的小型事物。科學模型則用於解釋與預測現實系統行為，如視覺化模型或預測模型。
+
+### 成熟度模型可驗證嗎？
+
+可以。成熟度模型可用質性或量化指標描述等級與項目。例如程式設計師可用「等級 1：寫出 Hello World 程式」到「等級 5：協同運作全球分散式系統」來驗證。


### PR DESCRIPTION
- Add a link to the Traditional Chinese version of the README
- Add a table of contents entry for "Maturity Models"
- Change maturity model level lists from asterisk to dash for consistency
- Reformat topic maturity model lists to use dashes and indentation for improved readability
- Add extra spacing and minor formatting improvements throughout the document
- Add a Traditional Chinese translation of the README as a new file